### PR TITLE
Class.forName is not required

### DIFF
--- a/database-programming-scala.md
+++ b/database-programming-scala.md
@@ -24,7 +24,6 @@ import java.sql.{Connection, ResultSet, Statement, PreparedStatement, DriverMana
 
 object Main {
    def main(args: Array[String]) {
-     Class.forName("com.mysql.jdbc.Driver")
      val conn: Connection = DriverManager.getConnection("jdbc:mysql://localhost/vocaloid", "nobody", "nobody")
 
      val st: PreparedStatement = conn.prepareStatement("SELECT * FROM artist WHERE birthday < ? ORDER BY birthday ASC")


### PR DESCRIPTION
JDBC 4.0(Java SE 6)からClass.forNameを使わなくてもJDBCドライバがロードさ
れるようになりました。

次のURLの"JDBC 4.0 APIで導入されたjava.sqlとjavax.sqlの機能"の項を参照し
てください。
https://docs.oracle.com/javase/jp/8/docs/api/java/sql/package-summary.html