### PR TITLE
s/implicit case class/implicit class/

### DIFF
--- a/foundation-of-programming-scala.md
+++ b/foundation-of-programming-scala.md
@@ -862,7 +862,7 @@ implicit def str2greatStr(s: String): GreatString = {
 "hello".bang // まるでStringに新しいメソッドが生えたように見える
 ```
 
-implicit case classを用いることもできる
+implicit classを用いることもできる
 ```scala
 implicit class GreatString(s: String)  {
   def bang: String = s + "!!!!"


### PR DESCRIPTION
`implicit class` についての解説で `implicit case class` となっている箇所があった。
ドキュメントには `an implicit class cannot be a case class` とある。
http://docs.scala-lang.org/overviews/core/implicit-classes.html